### PR TITLE
This is the correct update to x86emu-demo.c

### DIFF
--- a/demo/x86emu-demo.c
+++ b/demo/x86emu-demo.c
@@ -160,7 +160,7 @@ int emu_init(x86emu_t *emu, char *file)
   if(opt.bits_32) {
     /* set default data/address size to 32 bit */
     emu->x86.R_CS_ACC |= (1 << 10);
-
+    emu->x86.R_SS_ACC |= (1 << 10);
     /* maximize descriptor limits */
     emu->x86.R_CS_LIMIT =
     emu->x86.R_DS_LIMIT =
@@ -170,7 +170,7 @@ int emu_init(x86emu_t *emu, char *file)
     emu->x86.R_SS_LIMIT = ~0;
   }
 
-  if(!(f = fopen(file, "r"))) return 0;
+	if (!(f = fopen(file, "rb"))) return 0;
 
   while((i = fgetc(f)) != EOF) {
     x86emu_write_byte(emu, addr++, i);


### PR DESCRIPTION
**// add 32-bit stack when in 32 bit mode.** 
emu->x86.R_SS_ACC |= (1 << 10); // line 163

// All machine code is presumably binary 
// I am working with COFF object files
if (!(f = fopen(file, "rb"))) return 0; // line 173 open file in binary mode